### PR TITLE
Reorder cleanup in repeat_report()

### DIFF
--- a/src/pynetlogo/core.py
+++ b/src/pynetlogo/core.py
@@ -553,13 +553,15 @@ class NetLogoLink:
                         result = np.array([entry.strip('"') for entry in result.split()])
 
                 results[key] = result
-
-            os.remove(value)
-
+        
         # cleanup temp files and folders
         for fh in fhs:
-            os.close(fh)
-        os.rmdir(tempfolder)
+            os.close(fh) #free up file handle for re-use
+
+        for key, value in fns.items():
+             os.remove(value) #delete file by name
+
+        os.rmdir(tempfolder) #remove folder
 
         return results
 


### PR DESCRIPTION
Change order in which temporary files, handles, and folders are cleaned up in repeat_report(). If accepted, this will close https://github.com/quaquel/pyNetLogo/issues/72.